### PR TITLE
Add '-hpc' to gear name

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"name": "xcpengine-fw",
+	"name": "xcpengine-fw-hpc",
 		"label":  "XCPENGINE: pipeline for processing of  structural and functional data.",
 		"description": " The XCP imaging pipeline (XCP system) for  preprocessing of structural and functional data.",
 		"version": "1.06405",


### PR DESCRIPTION
This allows the HPC variant of the gear to be tracked separately (and sort in its own suite in the gear run dialog).